### PR TITLE
feat: hide gus urls in open source repositories

### DIFF
--- a/api/actions/__test__/createWorkItem.spec.js
+++ b/api/actions/__test__/createWorkItem.spec.js
@@ -232,12 +232,39 @@ describe('createGusItem action', () => {
             { id: '12345' },
             { interval: 60000, times: 5 }
         );
-        expect(getWorkItemUrl).toHaveBeenCalledWith({ sfci: 'SF123456' });
+        expect(getWorkItemUrl).toHaveBeenCalledWith({ sfci: 'SF123456' }, undefined);
         expect(Github.createComment).toHaveBeenCalledWith({
             req,
             body: `This issue has been linked to a new work item: https://12345.com`
         });
     });
+
+    it('should create a comment without the url when the git2gus.config.hideWorkItemUrl = true', async () => {
+        expect.assertions(2);
+        Github.createComment.mockReset();
+        Github.isSalesforceLabel.mockReturnValue(true);
+        Builds.resolveBuild.mockReturnValue(
+            Promise.resolve({ sfid: 'B12345' })
+        );
+        getWorkItemUrl.mockReset();
+        waitUntilSynced.mockReturnValue(Promise.resolve({ sfci: 'SF123456' }));
+        getWorkItemUrl.mockReturnValue('https://12345.com');
+        sails.hooks['issues-hook'].queue.push = async (data, done) => {
+            done(null, { id: '12345' });
+        };
+
+        const req1 = JSON.parse(JSON.stringify(req));
+        req1.git2gus.config.hideWorkItemUrl = true;
+
+        await fn(req1);
+
+        expect(waitUntilSynced).toHaveBeenCalledWith(
+            { id: '12345' },
+            { interval: 60000, times: 5 }
+        );
+        expect(getWorkItemUrl).toHaveBeenCalledWith({ sfci: 'SF123456' }, true);
+    });
+
     it('should create a comment when the "done" callback return the new work item but it not get synced', async () => {
         expect.assertions(3);
         Github.createComment.mockReset();

--- a/api/actions/__test__/linkToWorkItem.spec.js
+++ b/api/actions/__test__/linkToWorkItem.spec.js
@@ -29,6 +29,10 @@ global.sails = {
     }
 };
 
+const git2gus = {
+    config: {}
+};
+
 describe('linkToWorkItem action', () => {
     it('should call queue push with the right values when the issue is opened and the description matches the annotation', () => {
         const req = {
@@ -38,7 +42,8 @@ describe('linkToWorkItem action', () => {
                     url: 'github/test-salesforce-app/#32',
                     body: '@W-12345@ issue description'
                 }
-            }
+            },
+            git2gus
         };
         fn(req);
         expect(sails.hooks['issues-hook'].queue.push).toHaveBeenCalledWith(
@@ -64,7 +69,8 @@ describe('linkToWorkItem action', () => {
                         from: '@W-123@ description'
                     }
                 }
-            }
+            },
+            git2gus
         };
         fn(req);
         expect(sails.hooks['issues-hook'].queue.push).toHaveBeenCalledWith(
@@ -85,7 +91,8 @@ describe('linkToWorkItem action', () => {
                     url: 'github/test-salesforce-app/#32',
                     body: 'issue description'
                 }
-            }
+            },
+            git2gus
         };
         fn(req);
         expect(sails.hooks['issues-hook'].queue.push).not.toHaveBeenCalled();
@@ -117,7 +124,8 @@ describe('linkToWorkItem action', () => {
                 issue: {
                     url: 'github/test-salesforce-app/#32'
                 }
-            }
+            },
+            git2gus
         };
         fn(req);
         expect(sails.hooks['issues-hook'].queue.push).not.toHaveBeenCalled();
@@ -136,7 +144,8 @@ describe('linkToWorkItem action', () => {
                         from: 'new title'
                     }
                 }
-            }
+            },
+            git2gus
         };
         fn(req);
         expect(sails.hooks['issues-hook'].queue.push).not.toHaveBeenCalled();
@@ -158,12 +167,13 @@ describe('linkToWorkItem action', () => {
                     url: 'github/test-salesforce-app/#32',
                     body: '@W-12345@'
                 }
-            }
+            },
+            git2gus
         };
         await fn(req);
         expect(getWorkItemUrl).toHaveBeenCalledWith({
             id: 'abcd1234'
-        });
+        }, undefined);
         expect(createComment).toHaveBeenCalledWith({
             req,
             body:
@@ -190,7 +200,8 @@ describe('linkToWorkItem action', () => {
                     url: 'github/test-salesforce-app/#32',
                     body: '@W-12345@'
                 }
-            }
+            },
+            git2gus
         };
         await fn(req);
         expect(createComment).toHaveBeenCalledTimes(1);
@@ -220,7 +231,8 @@ describe('linkToWorkItem action', () => {
                     url: 'github/test-salesforce-app/#32',
                     body: '@W-12345@'
                 }
-            }
+            },
+            git2gus
         };
         await fn(req);
         expect(createComment).toHaveBeenCalledTimes(1);
@@ -249,7 +261,8 @@ describe('linkToWorkItem action', () => {
                     url: 'github/test-salesforce-app/#32',
                     body: '@W-12345@'
                 }
-            }
+            },
+            git2gus
         };
         await fn(req);
         expect(createComment).toHaveBeenCalledTimes(1);

--- a/api/actions/createWorkItem.js
+++ b/api/actions/createWorkItem.js
@@ -9,12 +9,12 @@ function getBuildErrorMessage(config, milestone) {
     }
     return `The defaultBuild value ${
         config.defaultBuild
-    } in \`.git2gus/config.json\` doesn't match any valid build in Salesforce.`;
+        } in \`.git2gus/config.json\` doesn't match any valid build in Salesforce.`;
 }
 
 module.exports = {
     eventName: GithubEvents.events.ISSUE_LABELED,
-    fn: async function(req) {
+    fn: async function (req) {
         const {
             issue: { labels, url, title, body, milestone },
             label
@@ -22,6 +22,7 @@ module.exports = {
         const { config } = req.git2gus;
 
         let productTag = config.productTag;
+        const { hideWorkItemUrl } = config;
         if (config.productTagLabels) {
             Object.keys(config.productTagLabels).forEach(productTagLabel => {
                 if (labels.some(label => label.name === productTagLabel)) {
@@ -58,7 +59,8 @@ module.exports = {
                                 return await Github.createComment({
                                     req,
                                     body: `This issue has been linked to a new work item: ${getWorkItemUrl(
-                                        syncedItem
+                                        syncedItem,
+                                        hideWorkItemUrl
                                     )}`
                                 });
                             }

--- a/api/actions/linkToWorkItem.js
+++ b/api/actions/linkToWorkItem.js
@@ -9,12 +9,14 @@ module.exports = {
         GithubEvents.events.ISSUE_OPENED,
         GithubEvents.events.ISSUE_EDITED
     ],
-    fn: async function(req) {
+    fn: async function (req) {
         const {
             action,
             issue: { url, body: description },
             changes
         } = req.body;
+
+        const { config: { hideWorkItemUrl } } = req.git2gus;
 
         if (action === 'edited' && !changes.body) {
             return;
@@ -42,8 +44,8 @@ module.exports = {
                         } else if (
                             item.priority &&
                             item.recordTypeId ===
-                                sails.config.salesforce
-                                    .investigationRecordTypeId
+                            sails.config.salesforce
+                                .investigationRecordTypeId
                         ) {
                             await addLabels({
                                 req,
@@ -52,7 +54,7 @@ module.exports = {
                         } else if (
                             item.recordTypeId &&
                             item.recordTypeId ===
-                                sails.config.salesforce.userStoryRecordTypeId
+                            sails.config.salesforce.userStoryRecordTypeId
                         ) {
                             await addLabels({
                                 req,
@@ -63,7 +65,8 @@ module.exports = {
                         return await createComment({
                             req,
                             body: `This issue has been linked to a new work item: ${getWorkItemUrl(
-                                item
+                                item,
+                                hideWorkItemUrl
                             )}`
                         });
                     }

--- a/api/services/Issues/__test__/getWorkItemUrl.spec.js
+++ b/api/services/Issues/__test__/getWorkItemUrl.spec.js
@@ -11,4 +11,16 @@ describe('getWorkItemUrl issues service', () => {
             'https://gus.lightning.force.com/lightning/r/ADM_Work__c/qwerty1234/view'
         );
     });
+
+    it('should retrun the work item name when hideUrl argument is true', () => {
+        process.env.WORK_ITEM_BASE_URL =
+            'https://gus.lightning.force.com/lightning/r/ADM_Work__c/';
+        const workItemUrl = getWorkItemUrl({
+            name: 'W-234123',
+            sfid: 'qwerty1234'
+        }, true);
+        expect(workItemUrl).toBe(
+            'W-234123'
+        );
+    });
 });

--- a/api/services/Issues/getWorkItemUrl.js
+++ b/api/services/Issues/getWorkItemUrl.js
@@ -1,3 +1,7 @@
-module.exports = function getWorkItemUrl(item) {
+module.exports = function getWorkItemUrl(item, hideUrl) {
+    if (hideUrl) {
+        return item.name;
+    }
+
     return `${process.env.WORK_ITEM_BASE_URL + item.sfid}/view`;
 };

--- a/views/pages/homepage.ejs
+++ b/views/pages/homepage.ejs
@@ -152,9 +152,18 @@ For more information, see:
             <li class="homepage-config-keys-item">
                 <span class="homepage-badge">statusWhenClosed</span>
                 <span class="homepage-config-key-description">
-                    It allows to specified the status `INTEGRATE`, `FIXED` or
+                    It allows to specify the status `INTEGRATE`, `FIXED` or
                     `CLOSED` of the work item when the Github issue gets
                     closed. By default: `INTEGRATE`.
+                </span>
+            </li>
+            <li class="homepage-config-keys-item">
+                <span class="homepage-badge">hideWorkItemUrl</span>
+                <span class="homepage-config-key-description">
+                    Some repositories are private or open source, when your repository is open source exposing internal
+                    urls is a security vulnerability.
+                    You will need to set this option to `true` in order to hide the url and use the WI-# instead.
+                    By default: `false`.
                 </span>
             </li>
         </ul>


### PR DESCRIPTION
Within Salesforce organization, some github repositories are private and some open source.

When a repository is open source, exposing internal urls is a security vulnerability.

This PR adds a configuration per repository (`.git2gus/config.json`) in order to hide the gus urls and show only the WI-#

```json
{
    "hideWorkItemUrl": true
}
```
Changes the comment from:
![image](https://user-images.githubusercontent.com/534821/62903758-a49b0b80-bd18-11e9-88b9-3ae7bfebab30.png)
to:
![image](https://user-images.githubusercontent.com/534821/62903644-440bce80-bd18-11e9-9a5b-09c9572bb7fa.png)
