### PR TITLE
Add default priority

### DIFF
--- a/api/models/Issues.js
+++ b/api/models/Issues.js
@@ -67,6 +67,7 @@ module.exports = {
             type: 'string',
             columnName: prefix + 'priority__c',
             isIn: ['P0', 'P1', 'P2', 'P3'],
+            defaultsTo: 'P2',
             required: false
         },
         syncState: {


### PR DESCRIPTION
This wasn't in the model for some odd reason - I remember adding it a while back. Without a default priority, user stories won't sync since GUS requires priorities for all work items.