### PR TITLE
Pick workitem Id from body of PR when title does not have a workitem Id

### DIFF
--- a/api/actions/__test__/createChangelist.spec.js
+++ b/api/actions/__test__/createChangelist.spec.js
@@ -22,7 +22,19 @@ const req = {
         pull_request: {
             title: 'pull request title @W-1234567@',
             url: 'https://api.github.com/repos/someuser/git2gustest/pulls/74',
-            closed_at: '2020-02-13T18:30:28Z'
+            closed_at: '2020-02-13T18:30:28Z',
+            body: 'some description\n\ndescription with workitem @W-7654321@\n\nmore description'
+        }
+    }
+};
+
+const reqWithWorkItemInBody = {
+    body: {
+        pull_request: {
+            title: 'pull request title withou workitem id',
+            url: 'https://api.github.com/repos/someuser/git2gustest/pulls/74',
+            closed_at: '2020-02-13T18:30:28Z',
+            body: 'description with workitem @W-7654321@'
         }
     }
 };
@@ -48,10 +60,22 @@ const reqWithWorkItemInWrongFormat = {
 };
 
 describe('createChangelist action', () => {
-    it('should call Issue.getName and Gus.createChangeListInGus with the right value', async () => {
+    it('should call Issue.getName and Gus.createChangeListInGus with workitem from title', async () => {
         Gus.getWorkItemIdByName.mockReturnValue('a071234');
         await fn(req);
         expect(Gus.getWorkItemIdByName).toHaveBeenCalledWith('W-1234567');
+
+        expect(Gus.createChangelistInGus).toHaveBeenCalledWith(
+            'someuser/git2gustest/pull/74',
+            'a071234'
+        );
+    });
+
+    it('should call Issue.getName and Gus.createChangeListInGus with workitem from body', async () => {
+        Gus.getWorkItemIdByName.mockReset();
+        Gus.getWorkItemIdByName.mockReturnValue('a071234');
+        await fn(reqWithWorkItemInBody);
+        expect(Gus.getWorkItemIdByName).toHaveBeenCalledWith('W-7654321');
 
         expect(Gus.createChangelistInGus).toHaveBeenCalledWith(
             'someuser/git2gustest/pull/74',

--- a/api/actions/__test__/createChangelist.spec.js
+++ b/api/actions/__test__/createChangelist.spec.js
@@ -23,7 +23,8 @@ const req = {
             title: 'pull request title @W-1234567@',
             url: 'https://api.github.com/repos/someuser/git2gustest/pulls/74',
             closed_at: '2020-02-13T18:30:28Z',
-            body: 'some description\n\ndescription with workitem @W-7654321@\n\nmore description'
+            body:
+                'some description\n\ndescription with workitem @W-7654321@\n\nmore description'
         }
     }
 };

--- a/api/actions/createChangelist.js
+++ b/api/actions/createChangelist.js
@@ -11,11 +11,13 @@ const GithubEvents = require('../modules/GithubEvents');
 
 module.exports = {
     eventName: GithubEvents.events.PULL_REQUEST_CLOSED,
-    fn: async function (req) {
+    fn: async function(req) {
         const {
             pull_request: { title, url, body }
         } = req.body;
-        const workItemInTitleOrBody = title.concat(body).match('@[Ww]-\\d{6,8}@');
+        const workItemInTitleOrBody = title
+            .concat(body)
+            .match('@[Ww]-\\d{6,8}@');
         if (workItemInTitleOrBody) {
             const workItemName = workItemInTitleOrBody[0].substring(
                 1,

--- a/api/actions/createChangelist.js
+++ b/api/actions/createChangelist.js
@@ -11,15 +11,15 @@ const GithubEvents = require('../modules/GithubEvents');
 
 module.exports = {
     eventName: GithubEvents.events.PULL_REQUEST_CLOSED,
-    fn: async function(req) {
+    fn: async function (req) {
         const {
-            pull_request: { title, url }
+            pull_request: { title, url, body }
         } = req.body;
-        const workItemInTitle = title.match('@[Ww]-\\d{6,8}@');
-        if (workItemInTitle) {
-            const workItemName = workItemInTitle[0].substring(
+        const workItemInTitleOrBody = title.concat(body).match('@[Ww]-\\d{6,8}@');
+        if (workItemInTitleOrBody) {
+            const workItemName = workItemInTitleOrBody[0].substring(
                 1,
-                workItemInTitle[0].length - 1
+                workItemInTitleOrBody[0].length - 1
             );
 
             const issueId = await Gus.getWorkItemIdByName(workItemName);


### PR DESCRIPTION
Based on feedback from some of the users, if workitem (in the format @W-1234567@) is not in title, we look if it is available in description and if so, use it.