### PR TITLE
Changelist URL bug fix - GUS expects the only relative Github url. Changing absolute URL to only pathname

### DIFF
--- a/api/actions/__test__/createChangelist.spec.js
+++ b/api/actions/__test__/createChangelist.spec.js
@@ -84,7 +84,7 @@ describe('createChangelist action', () => {
         expect(Gus.getWorkItemIdByName).toHaveBeenCalledWith('W-1234567');
 
         expect(Gus.createChangelistInGus).toHaveBeenCalledWith(
-            'https://github.com/Codertocat/Hello-World/commit/123456',
+            'Codertocat/Hello-World/commit/123456',
             'a071234'
         );
     });
@@ -96,7 +96,7 @@ describe('createChangelist action', () => {
         expect(Gus.getWorkItemIdByName).toHaveBeenCalledWith('W-7654321');
 
         expect(Gus.createChangelistInGus).toHaveBeenCalledWith(
-            'https://github.com/Codertocat/Hello-World/pull/2',
+            'Codertocat/Hello-World/pull/2',
             'a071234'
         );
     });

--- a/api/actions/utils/__test__/convertUrlToGusFormat.spec.js
+++ b/api/actions/utils/__test__/convertUrlToGusFormat.spec.js
@@ -11,21 +11,21 @@ describe('convertUrlToGusFormat', () => {
     it('should use merged commit when present - squash & merge case', () => {
         expect(
             convertUrlToGusFormat(
-                'repo-url.com/repo1',
+                'https://repo-url.com/repo1',
                 '123456',
-                'pr-url.com/pull/199',
+                'https://pr-url.com/pull/199',
                 '654321'
             )
-        ).toEqual('repo-url.com/repo1/commit/123456');
+        ).toEqual('repo1/commit/123456');
     });
 
     it('should use PR link when merged commit not present - non squashed merge case', () => {
         expect(
             convertUrlToGusFormat(
-                'repo-url.com/repo1',
+                'https://repo-url.com/repo1',
                 null,
-                'pr-url.com/pull/199'
+                'https://pr-url.com/pull/199'
             )
-        ).toEqual('pr-url.com/pull/199');
+        ).toEqual('pull/199');
     });
 });

--- a/api/actions/utils/convertUrlToGusFormat.js
+++ b/api/actions/utils/convertUrlToGusFormat.js
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+const URL = require('url');
 
 function convertUrlToGusFormat(repo_url, merge_commit_sha, pr_url) {
     if (merge_commit_sha) {
-        return repo_url.concat('/commit/').concat(merge_commit_sha);
+        return URL.parse(repo_url)
+            .pathname.concat('/commit/')
+            .concat(merge_commit_sha)
+            .substr(1);
     }
-    return pr_url;
+    return URL.parse(pr_url).pathname.substr(1);
 }
 exports.convertUrlToGusFormat = convertUrlToGusFormat;


### PR DESCRIPTION
The https://github.com part is automatically added by GUS. Hence the old url does not work.