### PR TITLE
Include checkin_by and checkin_date as part of changelist information

### DIFF
--- a/api/actions/__test__/createChangelist.spec.js
+++ b/api/actions/__test__/createChangelist.spec.js
@@ -29,7 +29,8 @@ const req = {
                 sha: '654321',
                 repo: { html_url: 'https://github.com/Codertocat/Hello-World' }
             },
-            merge_commit_sha: '123456'
+            merge_commit_sha: '123456',
+            merged_at: '2019-05-15T15:20:33Z'
         }
     }
 };
@@ -44,7 +45,8 @@ const reqWithWorkItemInBody = {
             head: {
                 sha: '654321',
                 repo: { html_url: 'https://github.com/Codertocat/Hello-World' }
-            }
+            },
+            merged_at: '2019-05-15T15:20:33Z'
         }
     }
 };
@@ -85,7 +87,8 @@ describe('createChangelist action', () => {
 
         expect(Gus.createChangelistInGus).toHaveBeenCalledWith(
             'Codertocat/Hello-World/commit/123456',
-            'a071234'
+            'a071234',
+            '2019-05-15T15:20:33Z'
         );
     });
 
@@ -97,7 +100,8 @@ describe('createChangelist action', () => {
 
         expect(Gus.createChangelistInGus).toHaveBeenCalledWith(
             'Codertocat/Hello-World/pull/2',
-            'a071234'
+            'a071234',
+            '2019-05-15T15:20:33Z'
         );
     });
 

--- a/api/actions/createChangelist.js
+++ b/api/actions/createChangelist.js
@@ -18,6 +18,7 @@ module.exports = {
                 html_url: pr_url,
                 body,
                 merge_commit_sha,
+                merged_at,
                 head: {
                     repo: { html_url: repo_url }
                 }
@@ -38,7 +39,7 @@ module.exports = {
                 pr_url
             );
             const issueId = await Gus.getWorkItemIdByName(workItemName);
-            Gus.createChangelistInGus(changelistUrl, issueId);
+            Gus.createChangelistInGus(changelistUrl, issueId, merged_at);
         }
     }
 };

--- a/api/services/Gus/createChangelistInGus.js
+++ b/api/services/Gus/createChangelistInGus.js
@@ -7,7 +7,11 @@
 
 const jsforce = require('jsforce');
 
-module.exports = function createChangelistInGus(relativeUrl, issueId) {
+module.exports = function createChangelistInGus(
+    relativeUrl,
+    issueId,
+    mergedAt
+) {
     const conn = new jsforce.Connection();
     conn.login(process.env.GUS_USERNAME, process.env.GUS_PASSWORD, err => {
         if (err) {
@@ -18,7 +22,9 @@ module.exports = function createChangelistInGus(relativeUrl, issueId) {
                 Perforce_Changelist__c: relativeUrl,
                 Work__c: issueId,
                 External_ID__c: relativeUrl,
-                Source__c: 'GitHub'
+                Source__c: 'GitHub',
+                Check_In_Date__c: mergedAt,
+                Check_In_By__c: process.env.GUS_USER
             },
             (err, ret) => {
                 if (err || !ret.success) {


### PR DESCRIPTION
Based on discussions with SFCI, we need to have "checkin date" populated, along with "Checkin By" in the changelists as we add them to GUS work item.
I have included merged_at time to be checkin_date and the same user that creates the GUS work item to be the checkin_by. Needs a config addition in the Git2Gus App once this is deployed.