### PR TITLE
Update salesforce.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ TOKEN_ORGS=asdf
 
 The GITHUB_TEST_ORG is the org where you have a repo with your test GH app installed to.
 
+Set the user credentials for your Salesforce org with these environment variables. Other forms of authentication with Salesforce are not yet supported.
+
+```
+GUS_USER=005xxxxxxxxxxxxAAA
+GUS_USERNAME=username@example.com
+GUS_PASSWORD=example_password
+```
+
 Make sure your test app has Read & Write access to Issues, Pull Requests, and Commit Statuses. Also make sure it has read access to "A single file" and the path should be `.git2gus/config.json`. You will also need to subscribe to events: Issue comment, Issues, and Label.
 
 ### Seeding your dev db

--- a/config/salesforce.js
+++ b/config/salesforce.js
@@ -6,7 +6,7 @@
  */
 
 module.exports.salesforce = {
-    salesforceUserId: process.env.SALESFORCE_USER_ID,
+    salesforceUserId: process.env.GUS_USER,
     status: ['INTEGRATE', 'FIXED', 'CLOSED'],
     userStoryRecordTypeId: process.env.USER_STORY_RECORD_TYPE_ID,
     /* Note: bugRecordTypeId is adm_work__c default record type */


### PR DESCRIPTION
Fixes #153. salesforce.js reads SALESFORCE_USER_ID from the environment, but other files use GUS_USER, and our prod deployment configures that name.