### PR TITLE
feat: add alternative annotation pattern GUS-W-

### DIFF
--- a/api/services/Issues/__test__/getAnnotation.spec.js
+++ b/api/services/Issues/__test__/getAnnotation.spec.js
@@ -13,7 +13,11 @@ describe('getAnnotation issues service', () => {
             '@W-12345678@',
             'some text @W-12345678@',
             'text@W-12345678@',
-            'some @W-12345678@ text'
+            'some @W-12345678@ text',
+            'GUS-W-12345678',
+            'some text GUS-W-12345678',
+            'textGUS-W-12345678',
+            'some GUS-W-12345678 text'
         ];
         descriptions.forEach(description => {
             expect(getAnnotation(description)).toBe('W-12345678');
@@ -27,6 +31,7 @@ describe('getAnnotation issues service', () => {
             '@W12345678@',
             'some text W-12345678@',
             'text@W-12345678',
+            'GAS-W-12345678',
             '',
             null,
             undefined,

--- a/api/services/Issues/__test__/getAnnotation.spec.js
+++ b/api/services/Issues/__test__/getAnnotation.spec.js
@@ -16,7 +16,6 @@ describe('getAnnotation issues service', () => {
             'some @W-12345678@ text',
             'GUS-W-12345678',
             'some text GUS-W-12345678',
-            'textGUS-W-12345678',
             'some GUS-W-12345678 text'
         ];
         descriptions.forEach(description => {
@@ -32,6 +31,7 @@ describe('getAnnotation issues service', () => {
             'some text W-12345678@',
             'text@W-12345678',
             'GAS-W-12345678',
+            'textGUS-W-12345678',
             '',
             null,
             undefined,

--- a/api/services/Issues/__test__/isSameAnnotation.spec.js
+++ b/api/services/Issues/__test__/isSameAnnotation.spec.js
@@ -8,16 +8,25 @@
 const isSameAnnotation = require('../isSameAnnotation');
 
 describe('isSameAnnotation issues service', () => {
+    const annotations = ['@W-12345@', 'GUS-W-12345'];
+
     it('should return true when is same annotation', () => {
         const descriptions = [
             '@W-12345@',
             'some text @W-12345@',
             'text@W-12345@',
             'some @W-12345@ text',
-            'some@W-12345@text'
+            'some@W-12345@text',
+            'GUS-W-12345',
+            'some text GUS-W-12345',
+            'textGUS-W-12345',
+            'some GUS-W-12345 text',
+            'someGUS-W-12345text'
         ];
         descriptions.forEach(description => {
-            expect(isSameAnnotation(description, '@W-12345@')).toBe(true);
+            annotations.forEach(annotation => {
+                expect(isSameAnnotation(description, annotation)).toBe(true);
+            });
         });
     });
     it('should return false when is not the same annotation', () => {
@@ -30,6 +39,11 @@ describe('isSameAnnotation issues service', () => {
             '@W12345@',
             'some text W-12345@',
             'text@W-12345',
+            'GUS-W-12345678',
+            'some text GUS-W-12345678',
+            'textGUS-W-12345678',
+            'some GUS-W-12345678 text',
+            'someGUS-W-12345678text',
             '',
             null,
             undefined,
@@ -38,7 +52,9 @@ describe('isSameAnnotation issues service', () => {
             12345
         ];
         descriptions.forEach(description => {
-            expect(isSameAnnotation(description, '@W-12345@')).toBe(false);
+            annotations.forEach(annotation => {
+                expect(isSameAnnotation(description, annotation)).toBe(false);
+            });
         });
     });
     it('should return false when both descriptions passed are null', () => {

--- a/api/services/Issues/__test__/isSameAnnotation.spec.js
+++ b/api/services/Issues/__test__/isSameAnnotation.spec.js
@@ -19,9 +19,7 @@ describe('isSameAnnotation issues service', () => {
             'some@W-12345@text',
             'GUS-W-12345',
             'some text GUS-W-12345',
-            'textGUS-W-12345',
-            'some GUS-W-12345 text',
-            'someGUS-W-12345text'
+            'some GUS-W-12345 text'
         ];
         descriptions.forEach(description => {
             annotations.forEach(annotation => {
@@ -41,9 +39,7 @@ describe('isSameAnnotation issues service', () => {
             'text@W-12345',
             'GUS-W-12345678',
             'some text GUS-W-12345678',
-            'textGUS-W-12345678',
             'some GUS-W-12345678 text',
-            'someGUS-W-12345678text',
             '',
             null,
             undefined,

--- a/api/services/Issues/getAnnotation.js
+++ b/api/services/Issues/getAnnotation.js
@@ -6,10 +6,28 @@
  */
 
 module.exports = function getAnnotation(description) {
+    const annotationMatchers = [
+        {
+            rex: /@w-\d+@/gi,
+            replace: /@/g
+        },
+        {
+            rex: /GUS-W-\d+/g,
+            replace: /GUS-/g
+        }
+    ];
+
     if (typeof description === 'string') {
-        const matches = description.match(/@w-\d+@/gi);
-        if (Array.isArray(matches) && matches.length > 0) {
-            return matches[0].replace(/@/g, '');
+        const matches = [];
+        annotationMatchers.forEach(matcher => {
+            let candidates = description.match(matcher.rex);
+            if (Array.isArray(candidates) && candidates.length > 0) {
+                matches.push(candidates[0].replace(matcher.replace, ''));
+            }
+        });
+
+        if (matches.length > 0) {
+            return matches[0];
         }
         return null;
     }

--- a/api/services/Issues/getAnnotation.js
+++ b/api/services/Issues/getAnnotation.js
@@ -12,7 +12,7 @@ module.exports = function getAnnotation(description) {
             replace: /@/g
         },
         {
-            rex: /GUS-W-\d+/g,
+            rex: /\bGUS-W-\d+\b/g,
             replace: /GUS-/g
         }
     ];


### PR DESCRIPTION
This commit adds an alternative annotation pattern, `GUS-W-`, to be used to identify a work item.

The reason for this is that GitHub autolinks
(https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources#configuring-autolinks-to-reference-external-resources) do not support patterns that begin with symbols (such as `@`). In order to keep auto linking _and_ enable git2gus, we add support for this additional pattern.

The pattern is case sensitive to help avoid issues with words ending with "gus" e.g. `argus`, `bogus`, `asparagus`.