### PR TITLE
changelists linked to GUS workitem will have PR link instead of commit link

### DIFF
--- a/api/actions/__test__/createChangelist.spec.js
+++ b/api/actions/__test__/createChangelist.spec.js
@@ -25,11 +25,6 @@ const req = {
             closed_at: '2020-02-13T18:30:28Z',
             body:
                 'some description\n\ndescription with workitem @W-7654321@\n\nmore description',
-            head: {
-                sha: '654321',
-                repo: { html_url: 'https://github.com/Codertocat/Hello-World' }
-            },
-            merge_commit_sha: '123456',
             merged_at: '2019-05-15T15:20:33Z'
         }
     }
@@ -42,10 +37,6 @@ const reqWithWorkItemInBody = {
             html_url: 'https://github.com/Codertocat/Hello-World/pull/2',
             closed_at: '2020-02-13T18:30:28Z',
             body: 'description with workitem @W-7654321@',
-            head: {
-                sha: '654321',
-                repo: { html_url: 'https://github.com/Codertocat/Hello-World' }
-            },
             merged_at: '2019-05-15T15:20:33Z'
         }
     }
@@ -57,10 +48,6 @@ const reqWithoutWorkItem = {
             title: 'pull request title',
             html_url: 'https://github.com/Codertocat/Hello-World/pull/2',
             closed_at: '2020-02-13T18:30:28Z',
-            head: {
-                sha: '123456',
-                repo: { html_url: 'https://github.com/Codertocat/Hello-World' }
-            }
         }
     }
 };
@@ -73,10 +60,6 @@ const reqWithWorkItemInWrongFormat = {
             closed_at: '2020-02-13T18:30:28Z',
             merged_at: '2020-02-13T18:30:28Z',
             merge_commit_sha: '123456',
-            head: {
-                sha: '123456',
-                repo: { html_url: 'https://github.com/Codertocat/Hello-World' }
-            }
         }
     }
 };
@@ -88,7 +71,7 @@ describe('createChangelist action', () => {
         expect(Gus.getWorkItemIdByName).toHaveBeenCalledWith('W-1234567');
 
         expect(Gus.createChangelistInGus).toHaveBeenCalledWith(
-            'Codertocat/Hello-World/commit/123456',
+            'Codertocat/Hello-World/pull/2',
             'a071234',
             '2019-05-15T15:20:33Z'
         );

--- a/api/actions/__test__/createChangelist.spec.js
+++ b/api/actions/__test__/createChangelist.spec.js
@@ -47,7 +47,7 @@ const reqWithoutWorkItem = {
         pull_request: {
             title: 'pull request title',
             html_url: 'https://github.com/Codertocat/Hello-World/pull/2',
-            closed_at: '2020-02-13T18:30:28Z',
+            closed_at: '2020-02-13T18:30:28Z'
         }
     }
 };
@@ -59,7 +59,7 @@ const reqWithWorkItemInWrongFormat = {
             html_url: 'https://github.com/Codertocat/Hello-World/pull/2',
             closed_at: '2020-02-13T18:30:28Z',
             merged_at: '2020-02-13T18:30:28Z',
-            merge_commit_sha: '123456',
+            merge_commit_sha: '123456'
         }
     }
 };

--- a/api/actions/createChangelist.js
+++ b/api/actions/createChangelist.js
@@ -19,11 +19,7 @@ module.exports = {
                 title,
                 html_url: pr_url,
                 body,
-                merge_commit_sha,
                 merged_at,
-                head: {
-                    repo: { html_url: repo_url }
-                }
             }
         } = req.body;
 
@@ -51,8 +47,6 @@ module.exports = {
             logger.info(`Extracted workItemName:${workItemName} from the req`);
 
             const changelistUrl = convertUrlToGusFormat(
-                repo_url,
-                merge_commit_sha,
                 pr_url
             );
             logger.info(

--- a/api/actions/createChangelist.js
+++ b/api/actions/createChangelist.js
@@ -15,12 +15,7 @@ module.exports = {
     fn: async function(req) {
         logger.info('createChangelist() Action called successfully');
         const {
-            pull_request: {
-                title,
-                html_url: pr_url,
-                body,
-                merged_at,
-            }
+            pull_request: { title, html_url: pr_url, body, merged_at }
         } = req.body;
 
         if (!merged_at) {
@@ -46,9 +41,7 @@ module.exports = {
             );
             logger.info(`Extracted workItemName:${workItemName} from the req`);
 
-            const changelistUrl = convertUrlToGusFormat(
-                pr_url
-            );
+            const changelistUrl = convertUrlToGusFormat(pr_url);
             logger.info(
                 `changelistUrl to be appended to the GUS workitem: ${changelistUrl}`
             );

--- a/api/actions/utils/__test__/convertUrlToGusFormat.spec.js
+++ b/api/actions/utils/__test__/convertUrlToGusFormat.spec.js
@@ -8,24 +8,10 @@
 const { convertUrlToGusFormat } = require('../convertUrlToGusFormat');
 
 describe('convertUrlToGusFormat', () => {
-    it('should use merged commit when present - squash & merge case', () => {
+    it('should get the relative path of the pull request', () => {
         expect(
-            convertUrlToGusFormat(
-                'https://repo-url.com/repo1',
-                '123456',
-                'https://pr-url.com/pull/199',
-                '654321'
+            convertUrlToGusFormat('https://github.com/jag-j/git2gustest/pull/130'
             )
-        ).toEqual('repo1/commit/123456');
-    });
-
-    it('should use PR link when merged commit not present - non squashed merge case', () => {
-        expect(
-            convertUrlToGusFormat(
-                'https://repo-url.com/repo1',
-                null,
-                'https://pr-url.com/pull/199'
-            )
-        ).toEqual('pull/199');
+        ).toEqual('jag-j/git2gustest/pull/130');
     });
 });

--- a/api/actions/utils/__test__/convertUrlToGusFormat.spec.js
+++ b/api/actions/utils/__test__/convertUrlToGusFormat.spec.js
@@ -10,7 +10,8 @@ const { convertUrlToGusFormat } = require('../convertUrlToGusFormat');
 describe('convertUrlToGusFormat', () => {
     it('should get the relative path of the pull request', () => {
         expect(
-            convertUrlToGusFormat('https://github.com/jag-j/git2gustest/pull/130'
+            convertUrlToGusFormat(
+                'https://github.com/jag-j/git2gustest/pull/130'
             )
         ).toEqual('jag-j/git2gustest/pull/130');
     });

--- a/api/actions/utils/convertUrlToGusFormat.js
+++ b/api/actions/utils/convertUrlToGusFormat.js
@@ -6,13 +6,7 @@
  */
 const URL = require('url');
 
-function convertUrlToGusFormat(repo_url, merge_commit_sha, pr_url) {
-    if (merge_commit_sha) {
-        return URL.parse(repo_url)
-            .pathname.concat('/commit/')
-            .concat(merge_commit_sha)
-            .substr(1);
-    }
-    return URL.parse(pr_url).pathname.substr(1);
+function convertUrlToGusFormat(pr_url) {
+    return URL.parse(pr_url).pathname.substring(1);
 }
 exports.convertUrlToGusFormat = convertUrlToGusFormat;


### PR DESCRIPTION
This pretty much reverses the work done as part of https://github.com/forcedotcom/git2gus/pull/75.
Since transmogrifier is now retired, we don't need the commit hashes any more (to find the associated tests in a PR). Additionally with this change, the changelist linking would even when someone does not 'squash and merge'.