### PR TITLE
Fix: Truncate long issue descriptions to prevent Salesforce overflow

### DIFF
--- a/api/actions/__test__/formatToGus.spec.js
+++ b/api/actions/__test__/formatToGus.spec.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const { formatToGus } = require('../formatToGus');
+
+describe('formatToGus', () => {
+    const testUrl = 'https://github.com/test/repo/issues/123';
+
+    it('should format short markdown content to HTML', () => {
+        const body = '# Test Issue\n\nThis is a test issue body.';
+        const result = formatToGus(testUrl, body);
+
+        expect(result).toContain('Github issue link:');
+        expect(result).toContain(testUrl);
+        expect(result).toContain('<h1>Test Issue</h1>');
+        expect(result).toContain('<p>This is a test issue body.</p>');
+    });
+
+    it('should handle empty body', () => {
+        const result = formatToGus(testUrl, '');
+
+        expect(result).toContain('Github issue link:');
+        expect(result).toContain(testUrl);
+    });
+
+    it('should handle null body', () => {
+        const result = formatToGus(testUrl, null);
+
+        expect(result).toContain('Github issue link:');
+        expect(result).toContain(testUrl);
+    });
+
+    it('should truncate content exceeding MAX_MARKDOWN_LENGTH', () => {
+        // Create a string longer than 10,000 characters
+        const longBody = 'A'.repeat(12000);
+        const result = formatToGus(testUrl, longBody);
+
+        expect(result).toContain('Content truncated due to length');
+        expect(result).toContain('See full issue on GitHub');
+        // Result should be significantly shorter than the original after truncation
+        expect(result.length).toBeLessThan(longBody.length);
+    });
+
+    it('should keep content under 10,000 characters intact', () => {
+        const body = 'A'.repeat(9000);
+        const result = formatToGus(testUrl, body);
+
+        expect(result).not.toContain('Content truncated');
+        expect(result).toContain('A'.repeat(100)); // Sample check
+    });
+
+    it('should preserve markdown formatting in truncated content', () => {
+        const longBody = '# Title\n\n' + 'Content paragraph. '.repeat(1000);
+        const result = formatToGus(testUrl, longBody);
+
+        expect(result).toContain('<h1>Title</h1>');
+        expect(result).toContain('Content truncated due to length');
+    });
+
+    it('should include truncation message at the end when truncated', () => {
+        const longBody = 'X'.repeat(15000);
+        const result = formatToGus(testUrl, longBody);
+
+        expect(result).toContain('[Content truncated due to length. See full issue on GitHub]');
+    });
+});

--- a/api/actions/formatToGus.js
+++ b/api/actions/formatToGus.js
@@ -1,12 +1,25 @@
 const remark = require('remark');
 const toHtml = require('remark-html');
 const markdown = require('remark-parse');
+
+// Salesforce Long Text Area default limit is 32,768 characters
+// Account for HTML expansion (~3x) and prepended text (~100 chars)
+const MAX_MARKDOWN_LENGTH = 10000; // Conservative limit to ensure we stay under 32,768 after HTML conversion
+
 function formatToGus(url, body) {
     var formattedDescription;
+    let processedBody = body || '';
+
+    // Truncate markdown if it exceeds the limit
+    if (processedBody.length > MAX_MARKDOWN_LENGTH) {
+        const truncationMessage = '\n\n---\n**[Content truncated due to length. See full issue on GitHub]**';
+        processedBody = processedBody.substring(0, MAX_MARKDOWN_LENGTH - truncationMessage.length) + truncationMessage;
+    }
+
     remark()
         .use(markdown)
         .use(toHtml)
-        .process(body, (err, file) => {
+        .process(processedBody, (err, file) => {
             if (err) {
                 throw err;
             }


### PR DESCRIPTION
## Summary
Fixes overflow issue where very long GitHub issue descriptions exceeded Salesforce's 32,768 character Long Text Area field limit, causing work item creation to fail with STRING_TOO_LONG errors.

## Changes
- Implemented truncation of GitHub issue bodies at 10,000 characters before HTML conversion
- Added MAX_MARKDOWN_LENGTH constant with safety margin for HTML expansion (~3x) and prepended text
- Truncated content includes helpful message directing users to full issue on GitHub
- Added comprehensive test suite for formatToGus function covering:
  - Normal markdown formatting
  - Empty and null body handling
  - Truncation of content exceeding 10,000 chars
  - Preservation of content under the limit
  - Markdown formatting in truncated content

## Root Cause
The issue occurred when GitHub webhook events contained very long issue descriptions that were:
1. Converted from markdown to HTML (increasing size by 1.5x-3x)
2. Prepended with GitHub issue link and separators (~60 chars)
3. Inserted into Salesforce Long Text Area fields without validation
4. Rejected by Salesforce with STRING_TOO_LONG error when exceeding 32,768 character limit

## Test plan
- [x] Added unit tests covering truncation logic, edge cases, and markdown formatting
- [ ] Manual testing with very long issue descriptions (>10,000 chars)
- [ ] Verify Salesforce work items are created successfully with truncated content
- [ ] Confirm truncation message renders properly in GUS

🤖 Generated with [Claude Code](https://claude.com/claude-code)